### PR TITLE
Feature/refresh token

### DIFF
--- a/src/main/java/oneus/GSMATCH/domain/request/controller/RequestController.java
+++ b/src/main/java/oneus/GSMATCH/domain/request/controller/RequestController.java
@@ -38,8 +38,7 @@ public class RequestController {
     }
 
     @PutMapping("/{requestId}")
-    public ResponseEntity<MsgResponseDto> modifyRequest(@PathVariable Long requestId,
-                                                        @RequestBody ModifyRequest request,
+    public ResponseEntity<MsgResponseDto> modifyRequest(@PathVariable Long requestId, @RequestBody ModifyRequest request,
                                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
         requestService.modifyRequest(requestId, request, userDetails.getUser());
         return ResponseEntity.ok(new MsgResponseDto("요청 수정 완료.", HttpStatus.OK.value()));

--- a/src/main/java/oneus/GSMATCH/domain/request/controller/RequestController.java
+++ b/src/main/java/oneus/GSMATCH/domain/request/controller/RequestController.java
@@ -45,9 +45,9 @@ public class RequestController {
         return ResponseEntity.ok(new MsgResponseDto("요청 수정 완료.", HttpStatus.OK.value()));
     }
 
-    @DeleteMapping("/{requestid}")
-    public ResponseEntity<MsgResponseDto> deleteRequest(@PathVariable Long requestid, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        requestService.deleteRequest(requestid, userDetails.getUser());
+    @DeleteMapping("/{requestId}")
+    public ResponseEntity<MsgResponseDto> deleteRequest(@PathVariable Long requestId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        requestService.deleteRequest(requestId, userDetails.getUser());
         return ResponseEntity.ok(new MsgResponseDto("요청 삭제 완료.", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/oneus/GSMATCH/domain/request/repository/RequestRepository.java
+++ b/src/main/java/oneus/GSMATCH/domain/request/repository/RequestRepository.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface RequestRepository extends JpaRepository<RequestEntity, Long> {
-    Optional<List<RequestEntity>> findByAuthor(UserEntity user);
-
     boolean existsByRequestId(Long requestId);
 
     void deleteByRequestId(Long requestId);

--- a/src/main/java/oneus/GSMATCH/domain/user/controller/UserController.java
+++ b/src/main/java/oneus/GSMATCH/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import oneus.GSMATCH.domain.user.entity.UserEntity;
 import oneus.GSMATCH.domain.user.repository.UserRepository;
 import oneus.GSMATCH.domain.user.service.UserService;
 import oneus.GSMATCH.global.jwt.JwtUtil;
+import oneus.GSMATCH.global.jwt.service.RefreshTokenService;
 import oneus.GSMATCH.global.security.UserDetailsImpl;
 import oneus.GSMATCH.global.util.MsgResponseDto;
 import org.springframework.http.HttpStatus;
@@ -26,6 +27,7 @@ public class UserController {
     public static final String BEARER_PREFIX = "Bearer ";
 
     private final UserService userService;
+    private final RefreshTokenService refreshTokenService;
 
     // 회원 가입
     @PostMapping("/signup")
@@ -38,8 +40,13 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<MsgResponseDto> login(@RequestBody LoginRequest loginRequestDto, HttpServletResponse response) {
         UserEntity user = userService.login(loginRequestDto);
+
+        String refreshToken = JwtUtil.createRefreshToken();
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, BEARER_PREFIX + JwtUtil.createToken(user.getName(), user.getRole()));
-        response.addHeader("Refresh-Token", BEARER_PREFIX + JwtUtil.createRefreshToken());
+        response.addHeader("Refresh-Token", BEARER_PREFIX + refreshToken);
+
+        refreshTokenService.saveRefreshToken(refreshToken, user.getUsersId());
+
         return ResponseEntity.ok(new MsgResponseDto("로그인 완료", HttpStatus.OK.value()));
     }
 

--- a/src/main/java/oneus/GSMATCH/domain/user/controller/UserController.java
+++ b/src/main/java/oneus/GSMATCH/domain/user/controller/UserController.java
@@ -17,12 +17,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class UserController {
+
+    public static final String BEARER_PREFIX = "Bearer ";
+
     private final UserService userService;
 
     // 회원 가입
@@ -36,7 +38,8 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<MsgResponseDto> login(@RequestBody LoginRequest loginRequestDto, HttpServletResponse response) {
         UserEntity user = userService.login(loginRequestDto);
-        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, JwtUtil.createToken(user.getName(), user.getRole()));
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, BEARER_PREFIX + JwtUtil.createToken(user.getName(), user.getRole()));
+        response.addHeader("Refresh-Token", BEARER_PREFIX + JwtUtil.createRefreshToken());
         return ResponseEntity.ok(new MsgResponseDto("로그인 완료", HttpStatus.OK.value()));
     }
 

--- a/src/main/java/oneus/GSMATCH/domain/user/controller/UserController.java
+++ b/src/main/java/oneus/GSMATCH/domain/user/controller/UserController.java
@@ -41,7 +41,7 @@ public class UserController {
     public ResponseEntity<MsgResponseDto> login(@RequestBody LoginRequest loginRequestDto, HttpServletResponse response) {
         UserEntity user = userService.login(loginRequestDto);
 
-        String refreshToken = JwtUtil.createRefreshToken();
+        String refreshToken = JwtUtil.createRefreshToken(user.getName());
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, BEARER_PREFIX + JwtUtil.createToken(user.getName(), user.getRole()));
         response.addHeader("Refresh-Token", BEARER_PREFIX + refreshToken);
 

--- a/src/main/java/oneus/GSMATCH/domain/user/dto/request/SignupRequest.java
+++ b/src/main/java/oneus/GSMATCH/domain/user/dto/request/SignupRequest.java
@@ -8,9 +8,6 @@ import lombok.NoArgsConstructor;
 import jakarta.validation.constraints.NotBlank;
 import static oneus.GSMATCH.global.util.UserStateEnum.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Getter
 @NoArgsConstructor
 public class SignupRequest {

--- a/src/main/java/oneus/GSMATCH/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/oneus/GSMATCH/domain/user/dto/response/UserInfoResponse.java
@@ -1,12 +1,9 @@
 package oneus.GSMATCH.domain.user.dto.response;
 
-import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import oneus.GSMATCH.domain.request.entity.RequestEntity;
-import oneus.GSMATCH.global.util.UserRoleEnum;
 import static oneus.GSMATCH.global.util.UserStateEnum.*;
 
 import java.util.List;

--- a/src/main/java/oneus/GSMATCH/domain/user/entity/UserEntity.java
+++ b/src/main/java/oneus/GSMATCH/domain/user/entity/UserEntity.java
@@ -1,8 +1,5 @@
 package oneus.GSMATCH.domain.user.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
 import oneus.GSMATCH.domain.request.entity.RequestEntity;
@@ -12,7 +9,6 @@ import static oneus.GSMATCH.global.util.UserStateEnum.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import static oneus.GSMATCH.global.util.UserStateEnum.*;
 
 @Entity
 @Getter

--- a/src/main/java/oneus/GSMATCH/domain/user/service/UserService.java
+++ b/src/main/java/oneus/GSMATCH/domain/user/service/UserService.java
@@ -1,7 +1,5 @@
 package oneus.GSMATCH.domain.user.service;
 
-import ch.qos.logback.core.spi.ErrorCodes;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import oneus.GSMATCH.domain.user.dto.request.LoginRequest;
 import oneus.GSMATCH.domain.user.dto.request.SignOutRequest;
@@ -13,7 +11,6 @@ import oneus.GSMATCH.domain.user.repository.UserRepository;
 import oneus.GSMATCH.global.exception.CustomException;
 import static oneus.GSMATCH.global.exception.ErrorCode.*;
 
-import oneus.GSMATCH.global.jwt.JwtUtil;
 import oneus.GSMATCH.global.util.UserRoleEnum;
 import static oneus.GSMATCH.global.util.UserStateEnum.*;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 import java.util.Collections;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/oneus/GSMATCH/global/config/WebSecurityConfig.java
+++ b/src/main/java/oneus/GSMATCH/global/config/WebSecurityConfig.java
@@ -75,6 +75,7 @@ public class WebSecurityConfig {
 
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
+                        .requestMatchers(new AntPathRequestMatcher("/refresh")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/auth/**")).permitAll()
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/oneus/GSMATCH/global/exception/ErrorCode.java
+++ b/src/main/java/oneus/GSMATCH/global/exception/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
 
     NOT_MATCH_INFORMATION(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
 
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 유효하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
 
     NOT_OK_REQUEST(HttpStatus.BAD_REQUEST, "유요한 요청이 아닙니다."),
 

--- a/src/main/java/oneus/GSMATCH/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/JwtAuthorizationFilter.java
@@ -33,8 +33,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(tokenValue)) {
             if (!jwtUtil.validateToken(tokenValue)) {
-                log.error("========= Token Error =========");
-                throw new RuntimeException();
+                throw new CustomException(INVALID_TOKEN); // 401 error
             }
 
             Claims info = jwtUtil.getUserInfoFromToken(tokenValue);

--- a/src/main/java/oneus/GSMATCH/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/JwtAuthorizationFilter.java
@@ -29,11 +29,16 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
 
+        if (req.getRequestURI().equals("/refresh")) {
+            filterChain.doFilter(req, res);
+            return;
+        }
+
         String tokenValue = jwtUtil.getJwtFromHeader(req);
 
         if (StringUtils.hasText(tokenValue)) {
             if (!jwtUtil.validateToken(tokenValue)) {
-                throw new RuntimeException();
+                throw new CustomException(INVALID_TOKEN);
             }
 
             Claims info = jwtUtil.getUserInfoFromToken(tokenValue);

--- a/src/main/java/oneus/GSMATCH/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/JwtAuthorizationFilter.java
@@ -33,7 +33,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(tokenValue)) {
             if (!jwtUtil.validateToken(tokenValue)) {
-                throw new CustomException(INVALID_TOKEN); // 401 error
+                throw new RuntimeException();
             }
 
             Claims info = jwtUtil.getUserInfoFromToken(tokenValue);

--- a/src/main/java/oneus/GSMATCH/global/jwt/JwtUtil.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/JwtUtil.java
@@ -51,11 +51,12 @@ public class JwtUtil {
                         .compact();
     }
 
-    public static String createRefreshToken() {
+    public static String createRefreshToken(String username) {
         Date date = new Date();
 
         return Jwts.builder()
                         .setIssuedAt(date)
+                        .setSubject(username)
                         .setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME))   // 만료 시간 : 현재시간 date.getTime() + 위에서 지정한 토큰 만료시간(60분)
                         .signWith(key, signatureAlgorithm)  // 암호화 알고리즘 (Secret key, 사용할 알고리즘 종류)
                         .compact();

--- a/src/main/java/oneus/GSMATCH/global/jwt/JwtUtil.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/JwtUtil.java
@@ -23,6 +23,7 @@ public class JwtUtil {
     public static final String AUTHORIZATION_KEY = "auth";      // 사용자 권한 값의 KEY
     public static final String BEARER_PREFIX = "Bearer ";       // Token 식별자
     private static final long TOKEN_TIME = 60 * 60 * 1000L;        // 토큰 만료시간 : 60분
+    private static final long REFRESH_TOKEN_TIME = 24 * 60 * 60 * 1000L;        // 토큰 만료시간 : 60분
 
     @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey (application.yml 에 추가해둔 값)
     private String secretKey;       // 그 값을 가져와서 secretKey 변수에 넣는다
@@ -41,12 +42,21 @@ public class JwtUtil {
         Date date = new Date();
 
         // 암호화
-        return BEARER_PREFIX +
-                Jwts.builder()
+        return Jwts.builder()
                         .setSubject(username)               // 사용자 식별자값(ID). 여기에선 username 을 넣음
                         .claim(AUTHORIZATION_KEY, role)     // 사용자 권한 (key, value)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))   // 만료 시간 : 현재시간 date.getTime() + 위에서 지정한 토큰 만료시간(60분)
                         .setIssuedAt(date)                  // 발급일
+                        .signWith(key, signatureAlgorithm)  // 암호화 알고리즘 (Secret key, 사용할 알고리즘 종류)
+                        .compact();
+    }
+
+    public static String createRefreshToken() {
+        Date date = new Date();
+
+        return Jwts.builder()
+                        .setIssuedAt(date)
+                        .setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME))   // 만료 시간 : 현재시간 date.getTime() + 위에서 지정한 토큰 만료시간(60분)
                         .signWith(key, signatureAlgorithm)  // 암호화 알고리즘 (Secret key, 사용할 알고리즘 종류)
                         .compact();
     }

--- a/src/main/java/oneus/GSMATCH/global/jwt/controller/RefreshTokenController.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/controller/RefreshTokenController.java
@@ -1,0 +1,25 @@
+package oneus.GSMATCH.global.jwt.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import oneus.GSMATCH.global.jwt.service.RefreshTokenService;
+import oneus.GSMATCH.global.security.UserDetailsImpl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RefreshTokenController {
+
+    private final RefreshTokenService refreshTokenService;
+
+    @GetMapping("/refresh")
+    public ResponseEntity<Void> refresh(HttpServletRequest request, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        refreshTokenService.refresh(request.getHeader("Refresh-Token"), userDetails.getUser().getUsersId());
+
+        return null;
+    }
+}

--- a/src/main/java/oneus/GSMATCH/global/jwt/controller/RefreshTokenController.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/controller/RefreshTokenController.java
@@ -34,14 +34,16 @@ public class RefreshTokenController {
     @GetMapping
     public ResponseEntity<Void> refresh(@RequestHeader("Refresh-Token") String token, HttpServletResponse response) {
         String refreshToken = token.substring(7);
-        refreshTokenService.refresh(refreshToken);
-        Claims userinfo = jwtUtil.getUserInfoFromToken(refreshToken);
 
+        // 리프레쉬 토큰 검증
+        refreshTokenService.refresh(refreshToken);
+        // 유저 정보 빼오기
+        Claims userinfo = jwtUtil.getUserInfoFromToken(refreshToken);
         String username = userinfo.getSubject();
         UserEntity user =  userRepository.findByName(username)
                 .orElseThrow(() -> new CustomException(INVALID_TOKEN));
 
-
+        // 에세스 토큰 재발급
         String accessToken = JwtUtil.createToken(user.getName(), user.getRole());
         response.addHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken);
 

--- a/src/main/java/oneus/GSMATCH/global/jwt/controller/RefreshTokenController.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/controller/RefreshTokenController.java
@@ -1,24 +1,49 @@
 package oneus.GSMATCH.global.jwt.controller;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import oneus.GSMATCH.domain.user.entity.UserEntity;
+import oneus.GSMATCH.domain.user.repository.UserRepository;
+import oneus.GSMATCH.global.exception.CustomException;
+import static oneus.GSMATCH.global.exception.ErrorCode.*;
+import oneus.GSMATCH.global.jwt.JwtUtil;
 import oneus.GSMATCH.global.jwt.service.RefreshTokenService;
 import oneus.GSMATCH.global.security.UserDetailsImpl;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/refresh")
 @RequiredArgsConstructor
 public class RefreshTokenController {
 
     private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
 
-    @GetMapping("/refresh")
-    public ResponseEntity<Void> refresh(HttpServletRequest request, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        refreshTokenService.refresh(request.getHeader("Refresh-Token"), userDetails.getUser().getUsersId());
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    @GetMapping
+    public ResponseEntity<Void> refresh(@RequestHeader("Refresh-Token") String token, HttpServletResponse response) {
+        String refreshToken = token.substring(7);
+        refreshTokenService.refresh(refreshToken);
+        Claims userinfo = jwtUtil.getUserInfoFromToken(refreshToken);
+
+        String username = userinfo.getSubject();
+        UserEntity user =  userRepository.findByName(username)
+                .orElseThrow(() -> new CustomException(INVALID_TOKEN));
+
+
+        String accessToken = JwtUtil.createToken(user.getName(), user.getRole());
+        response.addHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken);
 
         return null;
     }

--- a/src/main/java/oneus/GSMATCH/global/jwt/entity/RefreshToken.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/entity/RefreshToken.java
@@ -1,0 +1,29 @@
+package oneus.GSMATCH.global.jwt.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
+    @Builder
+    public RefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/oneus/GSMATCH/global/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/repository/RefreshTokenRepository.java
@@ -6,5 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByUserId(Long userId);
+    Optional<RefreshToken> findByRefreshToken(String refrshToken);
+    void deleteByRefreshToken(String refreshToken);
+    void deleteByUserId(Long userId);
+    boolean existsByUserId(Long userId);
+
 }

--- a/src/main/java/oneus/GSMATCH/global/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/repository/RefreshTokenRepository.java
@@ -3,5 +3,8 @@ package oneus.GSMATCH.global.jwt.repository;
 import oneus.GSMATCH.global.jwt.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
 }

--- a/src/main/java/oneus/GSMATCH/global/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package oneus.GSMATCH.global.jwt.repository;
+
+import oneus.GSMATCH.global.jwt.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/oneus/GSMATCH/global/jwt/service/RefreshTokenService.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/service/RefreshTokenService.java
@@ -1,0 +1,26 @@
+package oneus.GSMATCH.global.jwt.service;
+
+import lombok.RequiredArgsConstructor;
+import oneus.GSMATCH.global.exception.CustomException;
+import oneus.GSMATCH.global.exception.ErrorCode;
+import oneus.GSMATCH.global.jwt.JwtUtil;
+import oneus.GSMATCH.global.jwt.entity.RefreshToken;
+import oneus.GSMATCH.global.jwt.repository.RefreshTokenRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void saveRefreshToken(String token, Long userId) {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .refreshToken(token)
+                .userId(userId)
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+
+    }
+}

--- a/src/main/java/oneus/GSMATCH/global/jwt/service/RefreshTokenService.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/service/RefreshTokenService.java
@@ -2,7 +2,7 @@ package oneus.GSMATCH.global.jwt.service;
 
 import lombok.RequiredArgsConstructor;
 import oneus.GSMATCH.global.exception.CustomException;
-import oneus.GSMATCH.global.exception.ErrorCode;
+import static oneus.GSMATCH.global.exception.ErrorCode.*;
 import oneus.GSMATCH.global.jwt.JwtUtil;
 import oneus.GSMATCH.global.jwt.entity.RefreshToken;
 import oneus.GSMATCH.global.jwt.repository.RefreshTokenRepository;
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 public class RefreshTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtUtil jwtUtil;
 
     public void saveRefreshToken(String token, Long userId) {
         RefreshToken refreshToken = RefreshToken.builder()
@@ -21,6 +22,14 @@ public class RefreshTokenService {
                 .build();
 
         refreshTokenRepository.save(refreshToken);
+    }
 
+    public void refresh(String refreshToken, Long userId) {
+        RefreshToken savedToken = refreshTokenRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(INVALID_TOKEN));
+
+        if (!jwtUtil.validateToken(savedToken.getRefreshToken()) || !savedToken.getRefreshToken().equals(refreshToken)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
     }
 }

--- a/src/main/java/oneus/GSMATCH/global/jwt/service/RefreshTokenService.java
+++ b/src/main/java/oneus/GSMATCH/global/jwt/service/RefreshTokenService.java
@@ -34,6 +34,7 @@ public class RefreshTokenService {
         RefreshToken savedToken = refreshTokenRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new CustomException(NOT_MATCH_INFORMATION));
 
+        // 요청으로 온 리프레쉬 토큰 검증 + 디비에 저장되어있는 리프레시 토큰 검증
         if (!jwtUtil.validateToken(savedToken.getRefreshToken()) || !savedToken.getRefreshToken().equals(refreshToken)) {
             refreshTokenRepository.deleteByRefreshToken(refreshToken);
             throw new CustomException(INVALID_TOKEN);


### PR DESCRIPTION
## 개요 ✅
- 리프레시 토큰을 구현했습니다

## 작업내용 🔥
<img width="710" alt="스크린샷 2023-10-19 오후 11 45 31" src="https://github.com/ONEUS-team/gsmatch-back/assets/131235625/4d5b000e-4db2-4b7d-b8c6-78c923d75c0e">
<img width="1057" alt="스크린샷 2023-10-19 오후 11 46 10" src="https://github.com/ONEUS-team/gsmatch-back/assets/131235625/347ee293-418f-4d82-a69d-f2feb94d3314">

- 리프레시 토큰은 디비에 저장되며 `id`, `refreshToken`, `userId` 컬럼을 갖습니다.
> 리프레시 토큰 저장 디비는 redis로 변경해볼 예정

### Flow

- 로그인시 에세스 토큰과 리프레시 토큰을 헤더로 전달받음
- 에세스 토큰 만료시, 리프레시 토큰을 요청 헤더에 갖고 `/refresh` 요청을 보냄
- 응답 헤더에 새로 발급된 에세스 토큰을 전달받음

